### PR TITLE
Update tuyapi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"homepage": "https://github.com/joshstrange/eufy-robovac#readme",
 	"dependencies": {
-		"tuyapi": "^4.0.4"
+		"tuyapi": "^5.1.3"
 	},
 	"devDependencies": {
 		"@types/node": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eufy-robovac",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "NodeJS library to control Eufy RoboVac",
 	"main": "dist/index.js",
 	"types": "dist/index.d.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
 			'src',
 			'node_modules'
 		],
-		extensions: ['.ts', '.js' ]
+		extensions: ['.ts', '.js', '.json' ]
 	},
 	output: {
 		filename: 'index.js',


### PR DESCRIPTION
relates to https://github.com/joshstrange/homebridge-eufy-robovac/issues/3#issuecomment-529101386

in 5.* of tuyapi they're [supporting this new version of the firmware](https://github.com/codetheweb/tuyapi/pull/214), so it's just a case of making use of that.

The demo works with this, and updating the Homebridge plugin allows that to work too, which I can raise a PR for afterwards :)