### PR TITLE
Add build command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To test out if this library can talk to your RoboVac follow the steps below:
 git clone git@github.com:joshstrange/eufy-robovac.git
 cd eufy-robovac
 npm install
+npm run build
 npm run demo <deviceId> <localKey> <command>
 ```
 


### PR DESCRIPTION
The README was missing the `npm run build` command before running the demo.